### PR TITLE
Define key_pair Resource In Terraform

### DIFF
--- a/agent/infrastructure/README.md
+++ b/agent/infrastructure/README.md
@@ -20,6 +20,7 @@ You must ensure the following environment variables are set.
 * `TERRAFORM_STATE_S3_BUCKET_NAME`: The name of the S3 bucket you've previously created.
 * `TERRAFORM_STATE_S3_BUCKET_KEY`: The path in the bucket in which Terraform should look for the remote state file
 * `AWS_REGION`: Use `eu-west-1` for the time being.
+* `PUBLIC_KEY_PATH`: The local path to the public key you wish to associate to the ECS Container Instance. E.g `~/.ssh/webapptest_rsa.pub`
 
 ```bash
 cd infrastructure

--- a/agent/infrastructure/bin/infrastructure.sh
+++ b/agent/infrastructure/bin/infrastructure.sh
@@ -30,7 +30,8 @@ terraform remote pull
 terraform $type \
   -var "aws_access_key=$AWS_ACCESS_KEY_ID" \
   -var "aws_secret_key=$AWS_SECRET_ACCESS_KEY" \
-  -var "environment=$env"
+  -var "environment=$env" \
+  -var "public_key_path=$PUBLIC_KEY_PATH"
 
 if [ $type != "plan" ]; then
   terraform remote push

--- a/agent/infrastructure/key_pair.tf
+++ b/agent/infrastructure/key_pair.tf
@@ -1,0 +1,4 @@
+resource "aws_key_pair" "key_pair" {
+  key_name = "webapptest"
+  public_key = "${file("${var.public_key_path}")}"
+}

--- a/agent/infrastructure/variables.tf
+++ b/agent/infrastructure/variables.tf
@@ -1,3 +1,4 @@
 variable "environment" {}
 variable "aws_secret_key" {}
 variable "aws_access_key" {}
+variable "public_key_path" {}


### PR DESCRIPTION
Adds a mandatory option for associating a public key with the ECS container instance. Fixes https://github.com/jameshopkins/webapptest/issues/23