### PR TITLE
Add Debug Logging Module

### DIFF
--- a/app/server/index.js
+++ b/app/server/index.js
@@ -3,34 +3,34 @@ import net from 'net';
 import express from 'express';
 import { Lambda } from 'aws-sdk';
 import bodyParser from 'body-parser';
+import debug from 'debug';
 
-const log = (...args) =>
-  console.log(...args); // eslint-disable-line no-console
+const log = (namespace, ...args) =>
+  debug(`webapptest:${namespace}`)(...args);
 
 const server = createServer();
 const tcpServer = net.createServer();
 
 tcpServer.on('connection', conn => {
   const remoteAddress = `${conn.remoteAddress}:${conn.remotePort}`;
-
   conn.setEncoding('utf8');
 
   conn.on('data', d => {
-    log('connection data from %s: %j', remoteAddress, d);
+    log('tcp-server', 'connection data from %s: %j', remoteAddress, d);
     conn.write(d);
   });
 
   conn.once('close', () => {
-    log('connection from %s closed', remoteAddress);
+    log('tcp-server', 'connection from %s closed', remoteAddress);
   });
 
   conn.on('error', err => {
-    log('Connection %s error: %s', remoteAddress, err.message);
+    log('tcp-server', 'Connection %s error: %s', remoteAddress, err.message);
   });
 });
 
 tcpServer.listen(9000, () => {
-  log('server listening to %j', tcpServer.address());
+  log('tcp-server', 'server listening to %j', tcpServer.address());
 });
 
 const lambdaClient = new Lambda({
@@ -68,19 +68,19 @@ app.post('/spawn-agent', (req, res) => {
       tcpPort: process.env.TCP_PORT
     })
   }, (err) => {
-    log(err);
+    log('spawn-agent', err);
     res.sendStatus(200);
   });
 });
 
 app.use((err) => {
-  log(err);
+  log('server', err);
 });
 
 server.on('request', app);
 
 server.listen(port, () => {
-  log(`App server listening on port ${port}`);
+  log('server', `App server listening on port ${port}`);
 });
 
 export default app;

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "aws-sdk": "^2.5.0",
     "body-parser": "^1.15.2",
+    "debug": "^2.2.0",
     "express": "^4.14.0",
     "isomorphic-fetch": "^2.1.1",
     "lodash": "^4.15.0",


### PR DESCRIPTION
* This is pretty much a standard in many node modules including express & babel, can use DEBUG env variable to get output.

https://github.com/visionmedia/debug

Just use `DEBUG=webapptest:* node lib/server.js` to see specific `webapptest` logs (then you can namespace from there), great to just keep in the app when you start to have problems rather than a lot of people that add and remove `console.logs`, principle of instrument everything but sticks with the mantra of Linux programming.  If you don't have something useful to say then don't say it at all.

`DEBUG=*` for all debug logs including third party libraries such as express and Babel.
